### PR TITLE
Write config file to shared memory

### DIFF
--- a/cmd/gsw_service.go
+++ b/cmd/gsw_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/AarC10/GSW-V2/lib/db"
 	"github.com/AarC10/GSW-V2/lib/tlm"
+	"github.com/AarC10/GSW-V2/lib/ipc"
 	"os"
 	"os/signal"
 	"syscall"
@@ -34,9 +35,24 @@ func printTelemetryPackets() {
 
 func vcmInitialize() error {
 	// TODO: Need to set up configuration stuff
-	_, err := proc.ParseConfig("data/config/backplane.yaml")
+	data, err := os.ReadFile("data/config/backplane.yaml")
+	if err != nil {
+		fmt.Printf("Error reading YAML file: %v\n", err)
+		return err
+	}
+	_, err = proc.ParseConfigFile(data)
 	if err != nil {
 		fmt.Printf("Error parsing YAML: %v\n", err)
+		return err
+	}
+	configWriter, err := ipc.CreateIpcShmHandler("config", len(data), true)
+	if err != nil {
+		fmt.Printf("Error creating shared memory handler: %v\n", err)
+		return err
+	}
+	err = configWriter.Write(data)
+	if err != nil {
+		fmt.Printf("Error writing config to shared memory: %v\n", err)
 		return err
 	}
 

--- a/cmd/gsw_service.go
+++ b/cmd/gsw_service.go
@@ -34,7 +34,6 @@ func printTelemetryPackets() {
 }
 
 func vcmInitialize() error {
-	// TODO: Need to set up configuration stuff
 	data, err := os.ReadFile("data/config/backplane.yaml")
 	if err != nil {
 		fmt.Printf("Error reading YAML file: %v\n", err)
@@ -45,7 +44,7 @@ func vcmInitialize() error {
 		fmt.Printf("Error parsing YAML: %v\n", err)
 		return err
 	}
-	configWriter, err := ipc.CreateIpcShmHandler("config", len(data), true)
+	configWriter, err := ipc.CreateIpcShmHandler("config", len(data), true) // TODO cleanup
 	if err != nil {
 		fmt.Printf("Error creating shared memory handler: %v\n", err)
 		return err

--- a/cmd/mem_view/mem_view.go
+++ b/cmd/mem_view/mem_view.go
@@ -52,7 +52,7 @@ func printTelemetryPacket(startLine int, packet tlm.TelemetryPacket, rcvChan cha
 func main() {
 	configReader, err := ipc.CreateIpcShmReader("config")
 	if err != nil {
-			fmt.Println("*** Error accessing config file. Make sure the GSW service is running. ***")
+		fmt.Println("*** Error accessing config file. Make sure the GSW service is running. ***")
 		fmt.Printf("(%v)\n", err)
 		return
 	}

--- a/cmd/mem_view/mem_view.go
+++ b/cmd/mem_view/mem_view.go
@@ -61,7 +61,7 @@ func main() {
 		fmt.Printf("Error creating shared memory handler: %v\n", err)
 		return
 	}
-	data, err := configReader.Read()
+	data, err := configReader.ReadNoTimestamp()
 	if err != nil {
 		fmt.Printf("Error reading shared memory: %v\n", err)
 		return

--- a/cmd/mem_view/mem_view.go
+++ b/cmd/mem_view/mem_view.go
@@ -52,7 +52,8 @@ func printTelemetryPacket(startLine int, packet tlm.TelemetryPacket, rcvChan cha
 func main() {
 	configReader, err := ipc.CreateIpcShmReader("config")
 	if err != nil {
-		fmt.Printf("Error creating shared memory handler: %v\n", err)
+			fmt.Println("*** Error accessing config file. Make sure the GSW service is running. ***")
+		fmt.Printf("(%v)\n", err)
 		return
 	}
 	data, err := configReader.ReadNoTimestamp()

--- a/cmd/mem_view/mem_view.go
+++ b/cmd/mem_view/mem_view.go
@@ -50,13 +50,7 @@ func printTelemetryPacket(startLine int, packet tlm.TelemetryPacket, rcvChan cha
 }
 
 func main() {
-	fileinfo, err := os.Stat("/dev/shm/gsw-service-config")
-	if err != nil {
-		fmt.Printf("Error getting shm file info: %v\n", err)
-		return
-	}
-	filesize := int(fileinfo.Size()) // TODO fix unsafe int64 conversion
-	configReader, err := ipc.CreateIpcShmHandler("config",  filesize, false)
+	configReader, err := ipc.CreateIpcShmReader("config")
 	if err != nil {
 		fmt.Printf("Error creating shared memory handler: %v\n", err)
 		return
@@ -66,7 +60,7 @@ func main() {
 		fmt.Printf("Error reading shared memory: %v\n", err)
 		return
 	}
-	_, err = proc.ParseConfigFile(data)
+	_, err = proc.ParseConfigBytes(data)
 	if err != nil {
 		fmt.Printf("Error parsing YAML: %v\n", err)
 		return

--- a/lib/ipc/shm.go
+++ b/lib/ipc/shm.go
@@ -39,6 +39,7 @@ func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHan
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create file: %v", err)
 		}
+		/* maybe we don't need this
 		defer func(file *os.File) {
 			if file != nil {
 				err := file.Close()
@@ -47,6 +48,7 @@ func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHan
 				}
 			}
 		}(file)
+		*/
 
 		err = file.Truncate(int64(handler.size))
 		if err != nil {

--- a/lib/ipc/shm.go
+++ b/lib/ipc/shm.go
@@ -121,6 +121,15 @@ func (handler *IpcShmHandler) Read() ([]byte, error) {
 	return data, nil
 }
 
+func (handler *IpcShmHandler) ReadNoTimestamp() ([]byte, error) {
+	if handler.mode != modeReader {
+		return nil, fmt.Errorf("Handler is in writer mode")
+	}
+	data := make([]byte, handler.size-2*timestampSize)
+	copy(data, handler.data[:len(data)])
+	return data, nil
+}
+
 func (handler *IpcShmHandler) LastUpdate() time.Time {
 	timestamp := binary.BigEndian.Uint64(handler.data[handler.timestampOffset:])
 	return time.Unix(0, int64(timestamp))

--- a/proc/vcm.go
+++ b/proc/vcm.go
@@ -25,7 +25,10 @@ func ParseConfig(filename string) (*Configuration, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading YAML file: %v", err)
 	}
+	return ParseConfigFile(data)
+}
 
+func ParseConfigFile(data []byte) (*Configuration, error) {
 	// Unmarshalling doesn't seem to lead to errors with bad data. Better to check result config
 	_ = yaml.Unmarshal(data, &GswConfig)
 	if GswConfig.Name == "" {

--- a/proc/vcm.go
+++ b/proc/vcm.go
@@ -25,10 +25,10 @@ func ParseConfig(filename string) (*Configuration, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading YAML file: %v", err)
 	}
-	return ParseConfigFile(data)
+	return ParseConfigBytes(data)
 }
 
-func ParseConfigFile(data []byte) (*Configuration, error) {
+func ParseConfigBytes(data []byte) (*Configuration, error) {
 	// Unmarshalling doesn't seem to lead to errors with bad data. Better to check result config
 	_ = yaml.Unmarshal(data, &GswConfig)
 	if GswConfig.Name == "" {


### PR DESCRIPTION
The gsw_service writes the backplane.yaml file to shared memory so that other services are guaranteed to have access to the same config file.