### PR TITLE
Shared memory compatibility (with macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Launch Ground Software
 Ground software code for RIT Launch Initiative. Responsible for receiving telemetry over Ethernet and publishing to shared memory for other applications to use.
 
-### Compiling
+## Compiling
 By Golang convention, all files meant to be executed are stored in the cmd folder. 
 * The GSW service can be compiled by running `go build cmd/gsw_service.go` from the project root directory
 * GSW applications are stored in subdirectories within the cmd folder and the `go build` command can be ran on go files within those subdirectories
 
-### Running
+## Running
 You can always run the GSW service by doing a `./gsw_service` after building. For running any Go program though, instead of doing `go build (FILE_PATH)` you can do `go run (FILE_PATH)` instead.
 
-### Unit Tests
+### Compatibility
+Some machines do not have a /dev/shm directory. The directory used for shared memory can be changed with the flag `-shm (DIRECTORY_NAME)`. For example, `go run cmd/mem_view/mem_view.go -shm /someDirectory/RAMDrive`.
+
+## Unit Tests
 There are several unit tests that can be ran. You can do a `go test ./...` from the root project directory to execute all tests. It is also recommended to run with the -cover
 flag to get coverage statements.
 

--- a/lib/ipc/shm.go
+++ b/lib/ipc/shm.go
@@ -27,10 +27,6 @@ const (
 
 var shmDir = flag.String("shm", "/dev/shm", "directory to use for shared memory")
 
-func init() {
-    flag.Parse()
-}
-
 func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHandler, error) {
 	handler := &IpcShmHandler{
 		size:            size + timestampSize, // Add space for timestamp
@@ -38,6 +34,7 @@ func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHan
 		timestampOffset: size, // Timestamp is stored at the end
 	}
 
+    flag.Parse()
 	filename := filepath.Join(*shmDir, fmt.Sprintf("%s%s", shmFilePrefix, identifier))
 
 	if isWriter {
@@ -88,6 +85,7 @@ func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHan
 }
 
 func CreateIpcShmReader(identifier string) (*IpcShmHandler, error) {
+    flag.Parse()
 	fileinfo, err := os.Stat(filepath.Join(*shmDir, fmt.Sprintf("%s%s", shmFilePrefix, identifier)))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting shm file info: %v", err)

--- a/lib/ipc/shm.go
+++ b/lib/ipc/shm.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+    "flag"
 )
 
 type IpcShmHandler struct {
@@ -24,6 +25,12 @@ const (
 	shmFilePrefix = "gsw-service-"
 )
 
+var shmDir = flag.String("shm", "/dev/shm", "directory to use for shared memory")
+
+func init() {
+    flag.Parse()
+}
+
 func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHandler, error) {
 	handler := &IpcShmHandler{
 		size:            size + timestampSize, // Add space for timestamp
@@ -31,7 +38,7 @@ func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHan
 		timestampOffset: size, // Timestamp is stored at the end
 	}
 
-	filename := filepath.Join("/dev/shm", fmt.Sprintf("%s%s", shmFilePrefix, identifier))
+	filename := filepath.Join(*shmDir, fmt.Sprintf("%s%s", shmFilePrefix, identifier))
 
 	if isWriter {
 		handler.mode = modeWriter
@@ -81,7 +88,7 @@ func CreateIpcShmHandler(identifier string, size int, isWriter bool) (*IpcShmHan
 }
 
 func CreateIpcShmReader(identifier string) (*IpcShmHandler, error) {
-	fileinfo, err := os.Stat("/dev/shm/" + shmFilePrefix + identifier)
+	fileinfo, err := os.Stat(filepath.Join(*shmDir, fmt.Sprintf("%s%s", shmFilePrefix, identifier)))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting shm file info: %v", err)
 	}

--- a/lib/ipc/shm.go
+++ b/lib/ipc/shm.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
-    "flag"
+    	"flag"
 )
 
 type IpcShmHandler struct {


### PR DESCRIPTION
The -shm command line flag was added to enable the directory used for shared memory to optionally be changed from /dev/shm to any arbitrary directory. This enables macOS users to run the ground software on their local machine.