### PR TITLE
Measurement Scaling

### DIFF
--- a/cmd/telem_view/telem_view.go
+++ b/cmd/telem_view/telem_view.go
@@ -112,6 +112,12 @@ func main() {
 					}
 
 					// format & pad value
+					switch v := val.(type) {
+					case float32:
+						val = fmt.Sprintf("%.8f", v)
+					case float64:
+						val = fmt.Sprintf("%.8f", v)
+					}
 					valStr := fmt.Sprintf("%v", val)
 					valStr = padValue(valStr)
 

--- a/data/config/gsw_service.yaml
+++ b/data/config/gsw_service.yaml
@@ -1,4 +1,4 @@
-telemetry_config: data/config/receiver.yaml
+telemetry_config: data/config/backplane.yaml
 logging_config: data/config/logger.yaml
 database_host_name: localhost
 database_port_number: 8089

--- a/data/config/gsw_service.yaml
+++ b/data/config/gsw_service.yaml
@@ -1,4 +1,4 @@
-telemetry_config: data/config/backplane.yaml
+telemetry_config: data/config/receiver.yaml
 logging_config: data/config/logger.yaml
 database_host_name: localhost
 database_port_number: 8089

--- a/data/config/receiver.yaml
+++ b/data/config/receiver.yaml
@@ -1,4 +1,4 @@
-name: backplane
+name: receiver
 
 measurements:
     CURR_BATT:
@@ -37,16 +37,19 @@ measurements:
       size: 2
       type: int
       endianness: little
+      scaling: 0.001
     ACCEL_Y:
       name: ACCEL_Y
       size: 2
       type: int
       endianness: little
+      scaling: 0.001
     ACCEL_Z:
       name: ACCEL_Z
       size: 2
       type: int
       endianness: little
+      scaling: 0.001
 
     PRESSURE:
       name: PRESSURE

--- a/lib/tlm/tlm_interpreter.go
+++ b/lib/tlm/tlm_interpreter.go
@@ -9,11 +9,12 @@ import (
 
 // Measurement represents a single measurement in a telemetry packet.
 type Measurement struct {
-	Name       string `yaml:"name"`                 // Name of the measurement
-	Size       int    `yaml:"size"`                 // Size of the measurement in bytes
-	Type       string `yaml:"type,omitempty"`       // Type of the measurement (int, float)
-	Unsigned   bool   `yaml:"unsigned,omitempty"`   // Whether the measurement is unsigned
-	Endianness string `yaml:"endianness,omitempty"` // Endianness of the measurement (big, little)
+	Name       string  `yaml:"name"`                 // Name of the measurement
+	Size       int     `yaml:"size"`                 // Size of the measurement in bytes
+	Type       string  `yaml:"type,omitempty"`       // Type of the measurement (int, float)
+	Unsigned   bool    `yaml:"unsigned,omitempty"`   // Whether the measurement is unsigned
+	Endianness string  `yaml:"endianness,omitempty"` // Endianness of the measurement (big, little)
+	Scaling    float64 `yaml:"scaling,omitempty"`    // Scaling factor for the measurement (optional)
 }
 
 // TelemetryPacket represents information about a telemetry packet received over Ethernet.

--- a/proc/vcm.go
+++ b/proc/vcm.go
@@ -60,6 +60,12 @@ func ParseConfigBytes(data []byte) (*Configuration, error) {
 		} else if GswConfig.Measurements[k].Endianness != "little" && GswConfig.Measurements[k].Endianness != "big" {
 			return nil, fmt.Errorf("endianness specified as %s, instead of big or little", GswConfig.Measurements[k].Endianness)
 		}
+
+		if GswConfig.Measurements[k].Scaling == 0 {
+			entry := GswConfig.Measurements[k] // Workaround to avoid UnaddressableFieldAssign
+			entry.Scaling = 1.0                // Default scaling factor
+			GswConfig.Measurements[k] = entry
+		}
 	}
 
 	return &GswConfig, nil

--- a/proc/vcm.go
+++ b/proc/vcm.go
@@ -61,6 +61,7 @@ func ParseConfigBytes(data []byte) (*Configuration, error) {
 			return nil, fmt.Errorf("endianness specified as %s, instead of big or little", GswConfig.Measurements[k].Endianness)
 		}
 
+		// 0 is the default when parsed. If a user specifies 0, then it's probably a mistake.
 		if GswConfig.Measurements[k].Scaling == 0 {
 			entry := GswConfig.Measurements[k] // Workaround to avoid UnaddressableFieldAssign
 			entry.Scaling = 1.0                // Default scaling factor


### PR DESCRIPTION
# Description
Add an option to scale measurements in case we want to decrease the size of our downlinks, while trying to maintain some precision

# How Has This Been Tested?
Ran FSW simulations and ran the backplane and receiver configurations, comparing the values seen in the new telemetry viewer application.

# Checklist:
- [ ] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [ ] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [ ] The CI checks are passing
- [ ] I reviewed my own code in the GitHub diff and am sure that each change is intentional

