### PR TITLE
Fixed logger stacktrace

### DIFF
--- a/cmd/gsw_service.go
+++ b/cmd/gsw_service.go
@@ -151,9 +151,8 @@ func main() {
 			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", profilingPort), nil)
 
 			if err != nil {
-				logger.Warn("Unable to listen and serve")	
+				logger.Warn("Unable to listen and serve")
 			}
-
 
 		}()
 	}

--- a/cmd/gsw_service.go
+++ b/cmd/gsw_service.go
@@ -148,7 +148,13 @@ func main() {
 	if profilingPort != 0 {
 		go func() {
 			logger.Info(fmt.Sprintf("Running pprof server at localhost:%d", profilingPort))
-			http.ListenAndServe(fmt.Sprintf("localhost:%d", profilingPort), nil)
+			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", profilingPort), nil)
+
+			if err != nil {
+				logger.Warn("Unable to listen and serve")	
+			}
+
+
 		}()
 	}
 

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -53,7 +53,7 @@ func InitLogger() {
 		EncoderConfig:    encoderConfig,
 	}
 
-	logger = zap.Must(loggerConfig.Build())
+	logger = zap.Must(loggerConfig.Build(zap.AddCaller(), zap.AddCallerSkip(1)))
 }
 
 // loadLoggerConfig loads the logger configuration from a YAML file


### PR DESCRIPTION
This closes #34 

# Description
Added skipped a step in the stack trace so that it just goes to the next step, skips the logger file.

# How Has This Been Tested?
Added logging messages in multiple locations around the project and checked the logging messages, they all seem to be where they are supposed to be.

# Checklist:
- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional

